### PR TITLE
Revert "Fix a typo and reorder the introduction of SLO and SLI"

### DIFF
--- a/slo_bootstrap_guide.md
+++ b/slo_bootstrap_guide.md
@@ -6,9 +6,9 @@ Red Hat's SIG-SRE group has created a set of documents which share how some team
 
 ### Step 1: Familiarise Definitions
 
-**Service Level Indicator (SLI)** - A Service Level Indicator (SLI) is a specific metric that is used to measure the health/behavior of the system. These **indicators** may be exposed through the service (“white box”) itself or measured in a way that is external to the service (“black box”).
+**Service Level Objective (SLO)** - A Service Level Objective is a specific, measurable target to express the level of service provided to a service's custoemrs, be they internal or external. These **objectives** can be focused on a particular aspect of the service, such as a specific API endpoint.
 
-**Service Level Objective (SLO)** - A Service Level Objective is a specific, measurable target to express the level of service provided to a service's customers, be they internal or external. These **objectives** can be focused on a particular aspect of the service, such as a specific API endpoint.  The target for a given SLO is defined against a specific Service Level Indicator.
+**Service Level Indicator (SLI)** - A Service Level Indicator (SLI) is a specific metric that is used to measure against the objective. These **indicators** may be exposed through the service (“white box”) itself or measured in a way that is external to the service (“black box”).
 
 **Service Level Agreement (SLA)** - A Service Level Agreement is similar to a **SLO**, but is usually a legal document which imposes financial obligations from the service provider to their customers when the agreed service performance target is unmet.
 


### PR DESCRIPTION
Reverts operate-first/sre#34

As discussed on Slack:

The ordering of SLO and SLI in the bootstrap guide was intentional. The philosophy behind it will be included into the SLO Lifecycle guide; the typo that Ben corrected here will also be fixed in a subsequent PR.