### PR TITLE
Cleanup pass to consolidate markdownlint and spelling corrections

### DIFF
--- a/ADRs/RH/README.md
+++ b/ADRs/RH/README.md
@@ -1,1 +1,3 @@
+# RH
+
 This folder contains some sample Architecture Decision Records from teams within Red Hat.

--- a/ADRs/RH/SIG-SRE/ADR-00000 Template.md
+++ b/ADRs/RH/SIG-SRE/ADR-00000 Template.md
@@ -1,64 +1,52 @@
 # ADR-00000 Template
 
-Authors: 
-
+Authors:
 
 ## Status
 
-&lt;_Draft, Proposed, Reviewing, Accepted, Rejected, Superseded_> 
-
+&lt;_Draft, Proposed, Reviewing, Accepted, Rejected, Superseded_>
 
 ## Problem Statement
 
 &lt;_Why does this ADR exist? What decision are you trying to reach?_>
-
 
 ## Goals
 
 * &lt;_Clearly list the goals which this work will try to achieve._>
 * &lt;_The goals should be achievable, not visionary statements._>
 
-
 ## Non-goals
 
 * &lt;_If any of the goals might be interpreted too broadly, here's where you limit their scope._>
 
-
 ## Current Architecture
 
 * &lt;_If something is already solving the problem (even partially), here's where you mention it._>
-
 
 ## Proposed Architecture
 
 * &lt;_Present a high level overview of the proposed solution._>
 * &lt;_Make it concise and simple; put diagrams; be concrete, avoid using vague generalizations._>
 
-
 ## Challenges
 
 * &lt;_Call out any challenges here, e.g. upskilling needed, specific resources needed, very aggressive timelines if known, etc._>
-
 
 ## Alternatives Considered
 
 * &lt;_Were any other approaches to solving the issue considered? If yes, describe them here._>
 * &lt;_Focus on the differences in outcomes (both positive and negative) between the proposed architecture and the alternatives._>
 
-
 ## Dependencies
 
 * &lt;_Does this proposal depend on other things also being in place? List them._>
-
 
 ## Stakeholders
 
 * &lt;_Who needs to sign off on this proposal for it to be implementable?_>
   * &lt;_Since SIG-SRE ADRs impact how the SIG operates, the default set of stakeholders would consist of relevant SIG-SRE members (plus external stakeholders, if any)._>
 
-
 ## Consequences if Not Completed
 
 * &lt;_What happens if this proposal is not accepted and implemented?_>
 * &lt;_Start with immediate consequences, don't base your argument on what you think might happen 5 years from now._
-

--- a/ADRs/RH/SIG-SRE/ADR-00001 Document architecture decisions using the Architecture Decision Records approach and define their templates.md
+++ b/ADRs/RH/SIG-SRE/ADR-00001 Document architecture decisions using the Architecture Decision Records approach and define their templates.md
@@ -2,16 +2,13 @@
 
 Authors: Jeremy Eder
 
-
 ## Status
 
 Draft
 
-
 ## Problem Statement
 
 We need to capture our architecture decisions for all of Red Hat’s SIG-SRE and consumers. This capture should make it easy for people to find a given decision and refer to it. The decision context should be captured so we can question that decision when changes arise.
-
 
 ## Goals
 
@@ -20,24 +17,21 @@ We need to capture our architecture decisions for all of Red Hat’s SIG-SRE and
 * Capture decision context so we can revisit when context changes
 * Be easily discoverable
 
-
 ## Non-goals
 
 * Does not aim at achieving perfection from the get go
-
 
 ## Current Architecture
 
 * None
 
-
 ## Proposed Architecture
 
 * Embrace a well formed template for each Architecture Decision
-    * [[Template] Architecture Decision Record](ADR-00000%20Template.md)
+  * [[Template] Architecture Decision Record](ADR-00000%20Template.md)
 * Store each Architecture Decision Record (ADR) in [Operate First’s SRE repository](https://github.com/operate-first/sre/tree/main/ADRs/RH/SIG-SRE).
 * Each Architecture Decision Record is named “ADR-nnnnn Some title”
-    * nnnnn is a quasi monotonic number assigned at ADR creation time
+  * nnnnn is a quasi monotonic number assigned at ADR creation time
 * ADRs are immutable once their status moves to accepted
 * ADRs can supersede preceding ADRs: this is how a decision is changed.
 * No ADR once moved past Draft can be ‘deleted’ or ‘removed’.
@@ -46,6 +40,7 @@ We need to capture our architecture decisions for all of Red Hat’s SIG-SRE and
 ### ADR Status Fields
 
 Expected life cycle for each ADR will be as follows:
+
 1. **Draft**: An ADR in Draft indicates its a concept under consideration, being scoped, being written up. No action is expected from anyone other than the author, and there are no time pressures towards moving from the draft state.
 2. **Proposed**: ADRs can move to the proposed state once a sponsor has signed up, and the ADR can then start to be socialized within the team / with PMs and with RFCs / RFEs can be scoped in.
 3. **Reviewing**: Once moved to Reviewing state, the ADR must be brought to the SIG-SRE weekly call for consideration based on feedback already received. An ADR from this stage can either be moved back to the Proposed state, if gaps are identified or conversations need to be closed, or is Accepted / Rejected. And actions as follow-up should be executed.
@@ -53,29 +48,25 @@ Expected life cycle for each ADR will be as follows:
 5. **Rejected**: From the reviewing state, it's possible to move ADRs to a rejected state if they do not align with goals, or if stakeholders have fundamental concerns.
 6. **Superseded**: ADRs once they move to Accepted state can no longer be changed, since goals and execution is established. Changes would be implemented by replacement ADRs with the previous ADR being moved to ‘superseded’ state, and a comment being added into the ADR metadata itself indicating which ADR now supersedes this specific one. The general pattern to follow is the IETF RFC flow.
 
-
 ## Challenges
 
 * Each existing decisions should be identified and recaptured as Architecture Decision Records (ADR)
 * Since ADRs are numbered at creation time, it is possible that an ADR with a higher number is in effect before an ADR with a lower number. Shouldn't be a problem as long as they don’t contradict (nor supersede) one another.
 
-
 ## Alternatives Considered
 
 * Google doc free form documents: are hard to be versioned, searched and made to be immutable
-
 
 ## Dependencies
 
 * [[Template] Architecture Decision Record](ADR-00000%20Template.md)
 * Architecture Decision Records directory
 * Some materials on the concept of ADR
-    * [https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions.html](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions.html) 
-    * [https://adr.github.io/](https://adr.github.io/) 
-    * [https://adr.github.io/madr/](https://adr.github.io/madr/) 
-    * [https://engineering.atspotify.com/2020/04/14/when-should-i-write-an-architecture-decision-record/](https://engineering.atspotify.com/2020/04/14/when-should-i-write-an-architecture-decision-record/) 
-    * Note that we are deviating from these descriptions in some areas (including the template)
-
+  * [https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions.html](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions.html)
+  * [https://adr.github.io/](https://adr.github.io/)
+  * [https://adr.github.io/madr/](https://adr.github.io/madr/)
+  * [https://engineering.atspotify.com/2020/04/14/when-should-i-write-an-architecture-decision-record/](https://engineering.atspotify.com/2020/04/14/when-should-i-write-an-architecture-decision-record/)
+  * Note that we are deviating from these descriptions in some areas (including the template)
 
 ## Stakeholders
 
@@ -83,16 +74,13 @@ Expected life cycle for each ADR will be as follows:
 * Engineering Management and Product Management personas putting requirements on SRE teams
 * SIG-SRE workstream leads are the caretakers of these Architecture Decision Records and are Approvers of all ADR PRs
 
-
 ## Consequences if Not Completed
 
 * Ad-hoc decision recording that might be hard to find
 * Non-decisions slowing down the team progress
-
 
 ## Review Status
 
 Proposition is circulated to internal stakeholders.
 
 Status to converge within a week to accept unless concerns are arisen.
-

--- a/ADRs/RH/SIG-SRE/ADR-00002 Personas related to Managed Services.md
+++ b/ADRs/RH/SIG-SRE/ADR-00002 Personas related to Managed Services.md
@@ -2,11 +2,9 @@
 
 Authors: Craig Robinson
 
-
 ## Status
 
 Draft
-
 
 ## Problem Statement
 
@@ -16,16 +14,13 @@ A successful SRE practice requires a cross-functional group of stakeholders to e
 
 This ADR hopes to resolve the problem statement by identifying and documenting the key personas in a summary format. The output will be a document which will be referenced from other assets.
 
-
 ## Non-goals
 
 * This ADR does not aim at capturing every form or type of persona. It is purposefully generalised, utilising the most frequent persona types as experienced within the Red Hat 'Managed Services' context. The reason is that every organisation calls their personas by different names (and they will inevitably have different role descriptions). Nevertheless, this document hopes to capture the main types in a translatable way.
 
-
 ## Current Architecture
 
 * There was some pre-existing art in an internal Red Hat document entitled the "Application Services Primer". That was used as a source for this ADR.
-
 
 ## Proposed Architecture
 
@@ -72,7 +67,7 @@ QE is responsible for developing, maintaining, executing, and delivering various
 
 #### Site Reliability Engineer (SRE)
 
-The Site or Service Reliability Engineer is an essential part of the service. Their primary focus is ensuring that the services are "running". When there is a problem, it is up to them to resolve the issue as quickly as possible. However, this is only the end goal. The role of an SRE is to contribute to the reliability of the service so that the need to fix something is the exception rather than the rule. This is best epitomized in this quote by one of Red Hat's SRE Managers: "Do not accept repeated failure". That is, if something fails (e.g. SRE is alerted), then follow through with all "actions" so that the problem does not repeat. These actions can be things like: from identifying the issue with the responsible engineering team through to actually fixing the problem in code, personally. 
+The Site or Service Reliability Engineer is an essential part of the service. Their primary focus is ensuring that the services are "running". When there is a problem, it is up to them to resolve the issue as quickly as possible. However, this is only the end goal. The role of an SRE is to contribute to the reliability of the service so that the need to fix something is the exception rather than the rule. This is best epitomized in this quote by one of Red Hat's SRE Managers: "Do not accept repeated failure". That is, if something fails (e.g. SRE is alerted), then follow through with all "actions" so that the problem does not repeat. These actions can be things like: from identifying the issue with the responsible engineering team through to actually fixing the problem in code, personally.
 
 In many organizations, SRE functions support more than one service. Many projects undertaken by SRE teams provide the tooling, workflows and platforms needed to operate at scale. A key metric is for the SRE team to grow sub-linearly with "hockey stick" customer growth while minimizing toil and technical debt.
 
@@ -80,7 +75,7 @@ SREs are also valuable consultants, particularly in these key areas: observabili
 
 #### Support Engineer
 
-This persona provides assistance to Service Consumers, usually in the form of support cases raised by customers. They may require elevated levels of access to the service internals in order to help consumers, but in a way that ensures they cannot degrade the service itself. 
+This persona provides assistance to Service Consumers, usually in the form of support cases raised by customers. They may require elevated levels of access to the service internals in order to help consumers, but in a way that ensures they cannot degrade the service itself.
 
 #### Exec (VP+)
 
@@ -92,26 +87,21 @@ These are consumers of the services (and, often, the source of revenue). While t
 
 ***
 
-
 ## Challenges
 
 * There are an almost infinite number of permutations with respect to these personas, depending upon the circumstances and structure of the organisation. For example, small teams may have developers and SREs doing the same role. However, the purpose of this document is not to cover every nuance or situation otherwise this document would never have an endpoint.
-
 
 ## Alternatives Considered
 
 No alternatives were considered.
 
-
 ## Dependencies
 
 There are no dependencies.
 
-
 ## Stakeholders
 
 * Relevant SIG-SRE members who are dependent on the content in this document.
-
 
 ## Consequences if Not Completed
 

--- a/ADRs/RH/SIG-SRE/ADR-00004-Chaos-Testing-and-Engineering.md
+++ b/ADRs/RH/SIG-SRE/ADR-00004-Chaos-Testing-and-Engineering.md
@@ -2,11 +2,9 @@
 
 Authors: Naga Ravi Chaitanya Elluri
 
-
 ## Status
 
 Draft
-
 
 ## Problem Statement
 
@@ -20,7 +18,7 @@ There are assumptions that users might have when operating and running their app
 * Topology never changes.
 * The network is homogeneous.
 
-The assumptions led to a number of outages in production environments in the past.  The services suffered from poor performance or were inaccessible to the customers, leading to the service missing Service Level Agreement uptime promises, revenue loss, and a degradation in the perceived reliability of said services. 
+The assumptions led to a number of outages in production environments in the past.  The services suffered from poor performance or were inaccessible to the customers, leading to the service missing Service Level Agreement uptime promises, revenue loss, and a degradation in the perceived reliability of said services.
 
 To meet the needs and promised Service level agreements ( SLA’s ) for customers and users, it’s important to ensure that both platform as well as the services running on top of it are resilient to failures with minimal degradation in terms of performance for best user experience and avoid any potential downtime.
 
@@ -29,25 +27,22 @@ How users can actively adopt Chaos Engineering principles and methodology as par
 Evaluating SLO’s under chaotic conditions.
 
 Implications of not addressing the problem:
+
 * Service downtime impacting customers and users
 * Not being able to meet SLA’s
 * Degraded performance
 
-
 ## Goals
 
-Provide guidance on testing and hardening the services for customers, users and product teams to adopt. 
-
+Provide guidance on testing and hardening the services for customers, users and product teams to adopt.
 
 ## Non-goals
 
 Test Framework that is part of the Chaos Testing Guide will be actively maintained and can be leveraged but support in terms of assisting with testing one’s services is out of the scope.
 
-
 ## Current Architecture
 
 There isn’t an existing approach. The goal of the document is to add a new feature which doesn’t exist.
-
 
 ## Proposed Architecture
 
@@ -60,23 +55,19 @@ There isn’t an existing approach. The goal of the document is to add a new fea
 
 * Tie chaos testing practices into [various phases of the SRE](https://github.com/operate-first/sre/blob/main/sre_maturity.md) for customers and users to adopt depending on the maturity of their environment and team with an ultimate goal to adopt chaos testing in production environments during the available time window or error budget while still meeting the SLA.
 
-
 ## Challenges
 
 * Engineering cycles to actively maintain and support the Chaos Testing Guide and test framework.
-
 
 ## Alternatives Considered
 
 Alternatives haven’t been considered.
 
-
 ## Dependencies
 
 * For services running on OpenShift and Kubernetes:
-  * Krkn aka Kraken, framework to inject failures and evaluate the resilience and performance  - https://github.com/chaos-kubox/krkn
-  * Cerberus, tool which integrates with Kraken to monitor the health of the OpenShift cluster - https://github.com/chaos-kubox/cerberus
-
+  * [Krkn][krkn] aka Kraken, framework to inject failures and evaluate the resilience and performance
+  * [Cerberus][cerberus], tool which integrates with Kraken to monitor the health of the OpenShift cluster
 
 ## Stakeholders
 
@@ -84,10 +75,11 @@ Alternatives haven’t been considered.
 * SRE
 * QE
 
-
 ## Consequences if Not Completed
 
 * Service downtime impacting customers and users
 * Not being able to meet SLA’s
 * Degraded performance
 
+[krkn]: https://github.com/chaos-kubox/krkn
+[cerberus]: https://github.com/chaos-kubox/cerberus

--- a/ADRs/RH/SIG-SRE/ADR-00005 SLO Lifecycle.md
+++ b/ADRs/RH/SIG-SRE/ADR-00005 SLO Lifecycle.md
@@ -39,7 +39,7 @@ Break down the SLO lifecycle into three phases:
 
 The Research Phase consists of two lines of work which result in a SLO proposal agreement between stakeholders.
 
-Initially, Product Managers, Engineering Managers and SRE representatives will gather business and technical requirements that will inform the subsequent SLO discussions. The types of requirements may include what customer (both internal and external) expectations are for the service in terms of its performance, reliability and durability where applicable. Once the requirements are gathered, product managers and/or engineering leads for the service create a plan to implement the changes. The plan should contain enough details to successfully implement any required changes to the service. The changes might include [instrumenting SLIs][sli-guide], the creation of a monitoring dashboard, team policy and procedure changes and so on. The [RACI chart][raci-chart]] can be used as a guide for the Implementation Phase when the work is assigned.
+Initially, Product Managers, Engineering Managers and SRE representatives will gather business and technical requirements that will inform the subsequent SLO discussions. The types of requirements may include what customer (both internal and external) expectations are for the service in terms of its performance, reliability and durability where applicable. Once the requirements are gathered, product managers and/or engineering leads for the service create a plan to implement the changes. The plan should contain enough details to successfully implement any required changes to the service. The changes might include [instrumenting SLIs][sli-guide], the creation of a monitoring dashboard, team policy and procedure changes and so on. The [RACI chart][raci-chart] can be used as a guide for the Implementation Phase when the work is assigned.
 
 ### Implementation Phase
 
@@ -118,7 +118,7 @@ A parting thought for this section is to remember the purpose of the Service Lev
 
 ## Challenges
 
-* Teams may desire to adopt the guidelines in this document but lack the data to do so because they don't have any SLO, or a way to measure the remaining error budget. 
+* Teams may desire to adopt the guidelines in this document but lack the data to do so because they don't have any SLO, or a way to measure the remaining error budget.
 * Teams may face encounter difficulties scheduling "reliability work" by those who deprioritize it in favour of "feature work."
   * Related, teams may not have the throughput to address "reliability work" above "keeping the lights on" work. (See also toil management.)
 
@@ -148,6 +148,6 @@ Like with SELinux, the most value from the system comes from the "enforcing mode
 Key consequences for not adopting a SLO lifecycle is that there will continue to be ad-hoc practices if they exist. Teams may not set themselves up for success without adopting a lifecycle for SLOs.
 
 [sli-guide]: https://github.com/operate-first/sre/pulls/8
-[raci-chart]: #raci-chart-notcreatedyet
+[raci-chart]: https://github.com/operate-first/sre/blob/main/ADRs/RH/SIG-SRE/ADR-00006%20SLO%20RACI%20Chart.md
 [personas-adr]: https://github.com/operate-first/sre/blob/main/ADRs/RH/SIG-SRE/ADR-00002%20Personas%20related%20to%20Managed%20Services.md
 [selinux-project]: https://selinuxproject.org

--- a/ADRs/RH/SIG-SRE/ADR-00006 SLO RACI Chart.md
+++ b/ADRs/RH/SIG-SRE/ADR-00006 SLO RACI Chart.md
@@ -2,11 +2,9 @@
 
 Authors: Lisa Seelye <@lisa>, Jeremy Eder
 
-
 ## Status
 
 Draft
-
 
 ## Problem Statement
 
@@ -19,7 +17,6 @@ Create a matrix that breaks down the steps involved with the SLO lifecycle and u
 ## Non-goals
 
 Inclusion of every persona and every possible step is not desired. Some personas are not involved with this matrix and it is not feasible to enumerate every possible step.
-
 
 ## Current Architecture
 

--- a/ADRs/RH/SIG-SRE/ADR-00007-Error-Budget-Policy.md
+++ b/ADRs/RH/SIG-SRE/ADR-00007-Error-Budget-Policy.md
@@ -8,7 +8,7 @@ Draft
 
 ## Problem Statement
 
-A fundamential tenet of Site Reliability Engineering is to maximise customer satisfaction, not only through the function that a service provides, but also through its stability (aka reliability). This stability is measured through an SLO (Service Level Objective).
+A fundamental tenet of Site Reliability Engineering is to maximise customer satisfaction, not only through the function that a service provides, but also through its stability (aka reliability). This stability is measured through an SLO (Service Level Objective).
 
 This "SLO miss" can be referred to as the "error budget". The error budget can be described as the amount of "error" that a system can withstand without having a negative effect on the service, most notably, the customers "experience" of the service. Mathematically, it is often described as the inverse of the SLO: that is, as an example, there is an SLO target of 99.9% (3 nines) then the error budget is 0.1%. It can also be referred to as a measure of time (e.g. the error budget is 4 minutes per month).
 

--- a/ADRs/RH/SIG-SRE/ADR-00007-Error-Budget-Policy.md
+++ b/ADRs/RH/SIG-SRE/ADR-00007-Error-Budget-Policy.md
@@ -2,7 +2,6 @@
 
 Authors: Craig Robinson
 
-
 ## Status
 
 Draft
@@ -23,7 +22,6 @@ In many organisations, this question is often answered through the existence of 
 
 The aim of this ADR is to provide a template, with some rationale, for an example Error Budget Policy.
 
-
 ## Non-goals
 
 * This ADR does not aim at providing a definitive policy. The intention would be that consumers of this document would be able to take this example, based on the lessons learned from SRE teams already experienced in the running of services, and mold it to their own experience. It is purposefully generalised.
@@ -32,32 +30,31 @@ The aim of this ADR is to provide a template, with some rationale, for an exampl
 
 * An analysis of a number of existing Error Budget Policies was conducted, identifying the commonalities and the differences. The best practices articulated in this document was a synthesis of these sources.
 
-
 ## Proposed Architecture
 
 The proposed content is as follows:
 
 ***
 
-# Error Budget Policy (draft)
+## Error Budget Policy (draft)
 
 Service Name: \<Service/s Name\>
 
-# Service
+### Service
 
 \<Briefly describe the service/s under the scope of this document.\>
 
-# Definitions
+### Definitions
 
 * _SLI_: The Service Level Indicator is the carefully-considered measure for an aspect of the service that is considered necessary to its function (e.g. the login screen should be available).
 * _SLO_: The Service Level Objective is the desired target for the aspect measured by an SLI (e.g. the login screen should be available for 99% of the time).
 * _Error Budget_:  The Error budget is one of the fundamental metrics for service reliability. It is the measure of how much a service can be unreliable (e.g. fail) without impacting customers. Error budgets are always based on SLOs.
-* _SLO miss_: The state where the error budget has been consumed, and the level of service is not acceptable to the service owner. 
-* _Burn rate_: The speed you are consuming your error budget. For example, consuming 100% of the error budget in the expected period (for 30 days period - 30 days), consuming 200% of the error budget in the expected period (for 30 days period - 15 days). This should be used for SLO-based alerting. 
+* _SLO miss_: The state where the error budget has been consumed, and the level of service is not acceptable to the service owner.
+* _Burn rate_: The speed you are consuming your error budget. For example, consuming 100% of the error budget in the expected period (for 30 days period - 30 days), consuming 200% of the error budget in the expected period (for 30 days period - 15 days). This should be used for SLO-based alerting.
 * _Reliability Work_: The work that is needed to recover the service from an "SLO miss" state.
 * _Feature Work_: The work that is done to provide the features and functionality that is needed by that service.
 
-# Aim
+### Aim
 
 There are many inputs which affect the prioritization of work. The reliability of a service is a significant, but not the only, input to this process. The Error Budget is the primary metric that is used to inform the decision makers of issues that affect the reliability of a service, and by inference, the satisfaction of the customer with that service.
 
@@ -66,31 +63,31 @@ The questions that this is aiming to help answer is:
 * "What do we need to do now that the error budget is all gone?"
 * "How do we detect the early signs of system degradation, and what automated mechanisms do we have in place to intercept them?"
 
-# Scope
+### Scope
 
 The scope of this policy is limited to: \<service\>.
 
 The SLOs for this \<service\> are defined \<here\> (link to SLO definitions document).
 
-# Out-of-Scope
+### Out-of-Scope
 
 The scope of this policy does not apply to: \<service/aspect-of-service\>.
 
-# Current Status
+### Current Status
 
 The SLOs for this service are tracked via \<this\> dashboard (link to dashboard or visualization of SLOs).
 
-# Decision Making Principles
+### Decision Making Principles
 
-## Short-term
+#### Short-term
 
 * If the service has any remaining error budget for each SLO, releases (feature work) can proceed.
 * If the service has any remaining error budget for each SLO, but some anticipated "risky" work is scheduled (e.g. load tests) which may rapidly consume the remaining budget, then a risk assessment needs to be done, and a decision made as to whether this work should continue or not and/or feature work needs to be stopped.
 * If the service has consumed more than the allowed error budget for at least one SLO, all releases will stop except for security fixes and the work needed to recover from the "SLO miss" state (reliability work).
-    * However, if the error budget was consumed by miscategorised errors (false positives e.g. due to imperfect SLI implementation) and no customers were impacted, releases may continue. A bug for the miscategorisation must be prioritized and fixed as soon as possible.
-    * As the error budget is only one of the inputs, an exception process is available to enable the continuation of feature work at the discretion of the service owner (business).
+  * However, if the error budget was consumed by miscategorised errors (false positives e.g. due to imperfect SLI implementation) and no customers were impacted, releases may continue. A bug for the miscategorisation must be prioritized and fixed as soon as possible.
+  * As the error budget is only one of the inputs, an exception process is available to enable the continuation of feature work at the discretion of the service owner (business).
 
-## Long-Term
+#### Long-Term
 
 The following table is adapted from the ["Implementing SLOs"](https://sre.google/workbook/implementing-slos/#decision-making-using-slos-and-error-budgets) chapter in [The Site Reliability Workbook](https://sre.google/workbook/table-of-contents/). The intention is to use it for reviewing and being accountable to SLOs on a regular cadence. The inputs to this table are:
 
@@ -98,6 +95,7 @@ The following table is adapted from the ["Implementing SLOs"](https://sre.google
 * The amount of toil required to operate the service (Measured in terms of responding to alerts, manual work & customer reported issues from CEE)?
 * The level of customer satisfaction with the service (Measured by customer tickets and any direct customer engagement from the Business)?
 
+```html
 <table>
   <tr>
    <td colspan="3" ><strong>INPUTS</strong></td>
@@ -167,22 +165,23 @@ The following table is adapted from the ["Implementing SLOs"](https://sre.google
    <td>Stop "feature work" and focus on "reliability work" to resolve the customer satisfaction problem.</td>
   </tr>
 </table>
+```
 
-# Review Cadence
+i### Review Cadence
 
 It is absolutely necessary to setup a cadence for a regular review of the state of the error budget consumption at any point in time. The following is an example of what would be considered the minimum viable cadence required to keep on top of "burning" error budget. These meetings are an essential part of the "Iteration" phase as described in the [SLO Lifecycle ADR](https://github.com/operate-first/sre/pull/13). The reviews refer to these [personas](https://github.com/operate-first/sre/blob/main/ADRs/RH/SIG-SRE/ADR-00002%20Personas%20related%20to%20Managed%20Services.md).
 
-## Weekly Team Uptime Review
+#### Weekly Team Uptime Review
 
 The team/s (SRE/Engineering) responsible for the services need to collaboratively review the availability of the services on a regular basis. As per many typical engineering processes that have been well established, this can, and should, include regular sprint reviews (standups) and retrospectives. However, it has proven very beneficial to have a regular (e.g. weekly) review between, at least, SRE and engineering (but also possibly including the Product Owner). SRE, for example, are typically those who first identify that the error budget has been consumed, or is being consumed. At this meeting, they have the opportunity to inform the engineering team. If the error budget consumption coincides with an incident, this is often in the form of an RCA (Root Cause Analysis) document. The engineering team receive this information, and in close collaboration with the Product Owner, they can prioritise the rectification of the issue/s.
 
 Note: this regular weekly meeting does not replace the need for urgent action required in the case of a significant incident. It is expected that, at these times, ad-hoc review meetings can be called to expedite the resolution.
 
-## Monthly Uptime Review
+#### Monthly Uptime Review
 
 The weekly review meeting focuses on rapidly identifying issues to mitigate burning error budget as quickly as possible. However, as SLOs are often measured monthly, it is also beneficial to review the SLO performance on a monthly basis. The focus for this review is identifying trends over this longer time period. This is particularly useful in identifying SLOs that may need to be revised (for example, they are set to low or to high, or, they may be false alerts).
 
-# Escalation Process
+### Escalation Process
 
 If, during one of these review meetings, that an "SLO miss" is declared, then it may be an advantage to have a defined process that best enables the resolution of the issue causing the miss. That is, it can be "escalated" through the appropriate channels. The following is an example of an escalation process for this situation.
 
@@ -204,7 +203,7 @@ If any service team exceeds their error budget for a given time period (e.g. mon
 7. The team regularly update about the event status on the program call and in other venues as agreed.
 8. Once the issue has been addressed, the coordinator informs the stakeholders that this issue is resolved.
 
-# Exception Process
+### Exception Process
 
 In a scenario where there is a "SLO miss" that is affecting customers (i.e. valid), and, de-prioritizing committed work is not acceptable to stakeholders, a decision needs to be made between these two opposing options:
 
@@ -215,7 +214,7 @@ Decision #2 is a valid response and it is a knob that can be tuned (together wit
 
 The following is an example of such a process (for the purposes of this process, these [personas](https://github.com/operate-first/sre/blob/main/ADRs/RH/SIG-SRE/ADR-00002%20Personas%20related%20to%20Managed%20Services.md) are assumed):
 
-1. The Product Manager is best placed to assess all the inputs and propose the exception. The persona becomes the owner of this process, and they document the inputs affecting the decision and the cons of not doing #1 and proposing #2. JIRA is a good 
+1. The Product Manager is best placed to assess all the inputs and propose the exception. The persona becomes the owner of this process, and they document the inputs affecting the decision and the cons of not doing #1 and proposing #2. JIRA is a good
 2. The Product Manager organizes a meeting with the key internal stakeholders and presents the document. The decision is ratified.
 3. The Product Manager notifies the broader stakeholders. This would typically include:
     * An email to a team or project mailing list.

--- a/ADRs/RH/SIG-SRE/README.md
+++ b/ADRs/RH/SIG-SRE/README.md
@@ -1,1 +1,3 @@
+# SIG-SRE
+
 This folder contains ADRs from Red Hat's SRE Special Interest Group.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ make use of it with, at most, minor modification.
 
 ### Other Documents
 
-* A work in progess - the [SRE Maturity Model](./sre_maturity.md)
+* A work in progress - the [SRE Maturity Model](./sre_maturity.md)
 
     Moving to an SRE model generally happens in a series of steps rather than
     as a single big change. The SRE Maturity Model is intended to describe

--- a/picking_good_slis.md
+++ b/picking_good_slis.md
@@ -7,8 +7,9 @@ A core goal of Site Reliability Engineering (SRE) is to ensure the availability 
 Furthermore, the scope of monitoring should not be limited solely for use in deciding when to page an operations team. Metrics should be closely tied to business objectives, informing decisions on what work to prioritize and when to focus on adding new features versus improving reliability.
 
 To make this vision a reality, service teams rely on two key concepts:
-  * Service Level Indicators (SLIs) - A quantifiable metric that measures a specific aspect of a service's level of service.
-  * Service Level Objectives (SLOs) - A measurable, specific goal for a given service's level of service over time, based on one or more SLIs.
+
+* Service Level Indicators (SLIs) - A quantifiable metric that measures a specific aspect of a service's level of service.
+* Service Level Objectives (SLOs) - A measurable, specific goal for a given service's level of service over time, based on one or more SLIs.
 
 In starting on this [journey](sre_maturity.md), we recommend first identifying SLOs for your service. In doing so, consider the perspective of the end user and what aspects of level of service are most important to them. The details that follow offer guidance for selecting the best SLIs to measure adherence to your SLOs.
 
@@ -25,41 +26,45 @@ We recommend implementing at least one SLI for each of these signals.
 #### Latency
 
 Latency measures how long it takes your service to handle a request. Examples of how to measure this might be:
-  * How long does it take for a page of your browser-based application to load
-  * How long it takes for an API system to respond to an API call
-  * How long does a database query take
-  * How long does it take to provision some user-requested environment or resource
+
+* How long does it take for a page of your browser-based application to load
+* How long it takes for an API system to respond to an API call
+* How long does a database query take
+* How long does it take to provision some user-requested environment or resource
 
 Using latency as an SLI can sometimes be a difficult choice, or even the wrong choice. For example, if your service allows users to configure some aspect of it such that the time it takes for a request or transaction is variable, the latency could change dramatically from user to user. If you have an authorisation callback in your API that needs to wait on some 3rd party or customer system before it can perform the requested operation, your service is completely dependent on that external system for the overall latency. Alternatively, if you provide a message broker service,  a user can configure a client to read messages at varying intervals, or even skip reading messages. There is no guarantee of consistency for which you can measure the latency of a full end to end transaction (which the user actually cares about).
-Take care to allow for all potential points of latency when abstracting a feature into an SLI, particularly when the service is not a simple http API. You may even consider using an approximation of user interaction as an indicator. For example, a canary application that regularly produces and then consumes a message from a broker. This end-to-end interaction can be captured as metrics and used to approximate what the user experience is like in a controlled environment, leaving users to extrapolate from that if their own experience of the service is within operational parameters. 
+Take care to allow for all potential points of latency when abstracting a feature into an SLI, particularly when the service is not a simple http API. You may even consider using an approximation of user interaction as an indicator. For example, a canary application that regularly produces and then consumes a message from a broker. This end-to-end interaction can be captured as metrics and used to approximate what the user experience is like in a controlled environment, leaving users to extrapolate from that if their own experience of the service is within operational parameters.
 
 #### Traffic
 
 Traffic measures how many concurrent workloads are being handled by a service at a point in time. Examples of how to measure this might be:
-  * How many concurrent users have active sessions in your web app
-  * How many messages per second are published to a message queue
-  * How many requests per second is your API handling
-  * How much network bandwidth is your application serving
+
+* How many concurrent users have active sessions in your web app
+* How many messages per second are published to a message queue
+* How many requests per second is your API handling
+* How much network bandwidth is your application serving
 
 If you are running a multi-tenanted service, these indicators can have a dual purpose. They can track the overall traffic of your service, which is useful for overall scaling concerns. They can also be used to track individual tenants of your service and how much traffic is spread or contended between tenants. This would require a simple tenant label on the indicator metric to allow filtering etc. A traffic indicator could show how a small subset of users affect the level of service for all users. (Having guard rails to prevent this happening is a different topic altogether). For example, in a kubernetes environment there may be different instances of a service all running in the same network zone as each other. A lot of network traffic going to 1 user's instance may exhaust the network for other users trying to send traffic to their own instance in the same network zone.
 
 #### Errors
 
 Errors measures the rate of failed requests to your service. Examples of how to measure this might be:
-  * The number of requests to your API that have a 5xx response code
-  * The number of errors seen on the client-side by users of your web app
-  * The rate of dropped packets on a network
+
+* The number of requests to your API that have a 5xx response code
+* The number of errors seen on the client-side by users of your web app
+* The rate of dropped packets on a network
 
 When using errors as an SLI, be careful to avoid choosing a metric where user initiated errors can contribute. If possible, find a way to distinguish between the different sources of error and only include non-user initiated errors in the indicator. This maps well to a http service where 5xx response codes generally mean it’s our problem rather than something the user did. 4xx responses might be customer errors, but could also be signs of other issues (confusing API properties, client UX, etc.).  The distinction may be more difficult to tease out of non-HTTP services. Depending on the service protocol, you may need to expose different metrics or labels depending on the source of the error. For example, in a message broker system there may be a general count of errors when consuming a message. A message could fail to be consumed for any number of reasons, caused by a server problem or client misconfiguration.
 
 #### Saturation
 
 Saturation measures the utilization of your service relative to that point at which it would be considered "full". Effectively implementing SLIs for saturation requires knowledge, or at least a hypothesis, of the capacity for your service and the limiting factor. Examples of how to measure this might be:
-  * CPU utilization percentage for services that are highly CPU-constrained
-  * Memory utilization percentage for services that are highly Memory constrained
-  * Storage capacity usage percentage
-  * Network bandwidth capacity usage percentage
-  * API request count as a percentage of maximum capacity
+
+* CPU utilization percentage for services that are highly CPU-constrained
+* Memory utilization percentage for services that are highly Memory constrained
+* Storage capacity usage percentage
+* Network bandwidth capacity usage percentage
+* API request count as a percentage of maximum capacity
 
 Indicators around saturation can be used as a safeguard in a well managed environment where limits are not expected to be reached. However, having unused/wasted resources is not ideal, so you may want to increase capacity on demand. Whether that means a manual increase or an automated scaling of instances, the important piece is having the right indicator of saturation for your service i.e. what is likely to be exhausted first as users use my service.
 
@@ -69,7 +74,7 @@ While not exhaustive, here are a few commonly-made mistakes that we recommend ag
 
 #### Alerting on everything
 
-Many teams attempt to create alerting rules for every metric they collect. This frequently results in “pager fatigue”, or receiving a high number of unactionable alerts or alerts for things that don’t really matter. 
+Many teams attempt to create alerting rules for every metric they collect. This frequently results in “pager fatigue”, or receiving a high number of unactionable alerts or alerts for things that don’t really matter.
 
 Instead, focus on picking the right SLOs, then pick SLIs that help you measure them and alert when you’re in or approaching breach of SLO.
 

--- a/picking_good_slos.md
+++ b/picking_good_slos.md
@@ -35,7 +35,7 @@ There are two main paths this could be navigated, and each should consider if th
 
 * Have good SLIs based on what is important to customers.
 * Reflect on customer experience: Customer satisfaction drives the sustainability of the business, so make sure to focus on critical paths that make customers happy.
-* Define Expectations vs Reality SLOs: Distinct aspirational SLO target levels from those you can acually achieve.
+* Define Expectations vs Reality SLOs: Distinct aspirational SLO target levels from those you can actually achieve.
 * Start somewhere: Don't wait until you find the best target levels to create an SLO.
 * Iterate often: You need continuously re-evaluate reliability targets and update the SLOs based on more realistic target goals.
 * Never forget external dependencies: Monitoring external dependencies and considering them while crafting SLOs is important as they have a direct impact on the reliability targets.

--- a/picking_good_slos.md
+++ b/picking_good_slos.md
@@ -1,57 +1,43 @@
 # How to pick a good SLO
 
-A Service Level Objective (SLO) is a measurable, specific goal for a given service's reliability level of service over time, based on one or more SLIs (Service Level Indicator).
-The SLI is a measure of "what-you-want" (e.g. x should be true) and the SLO is the measure of "how-much-you-want-it" (e.g. y% of the time). Ideally, the SLOs/SLIs are reflecting 
-of some aspect of the service which a customer would consider necessary to the satisfactory usage of that service. For example, as a customer, it is really important for me to be 
-able to get an answer back for my search within 5 seconds (what I want) at least 99% of the time (how much I want it). These are called "customer-centric" SLOs and the 
-reflect a customer's view of the "reliability" they expect for that service. To learn more about SLIs, check out our article on how to [pick good SLIs](./picking_good_slis.md).
+A Service Level Objective (SLO) is a measurable, specific goal for a given service's reliability level of service over time, based on one or more SLIs (Service Level Indicator). The SLI is a measure of "what-you-want" (e.g. x should be true) and the SLO is the measure of "how-much-you-want-it" (e.g. y% of the time). Ideally, the SLOs/SLIs are reflecting of some aspect of the service which a customer would consider necessary to the satisfactory usage of that service. For example, as a customer, it is really important for me to be able to get an answer back for my search within 5 seconds (what I want) at least 99% of the time (how much I want it). These are called "customer-centric" SLOs and the reflect a customer's view of the "reliability" they expect for that service. To learn more about SLIs, check out our article on how to [pick good SLIs](./picking_good_slis.md).
 
-An SLO is used to quantify customer experience.
-Furthermore, SLOs enable [service owners](./ADRs/RH/SIG-SRE/ADR-00002%20Personas%20related%20to%20Managed%20Services.md#service-owner) to avoid false positives in alerting and help focus on symptom-based alerting.
-SLOs can vary from organization to organization. Consequently, there is no single formula that could define the appropriate reliability target. 
+An SLO is used to quantify customer experience. Furthermore, SLOs enable [service owners](./ADRs/RH/SIG-SRE/ADR-00002%20Personas%20related%20to%20Managed%20Services.md#service-owner) to avoid false positives in alerting and help focus on symptom-based alerting. SLOs can vary from organization to organization. Consequently, there is no single formula that could define the appropriate reliability target.
 
-The SLO is based on good SLIs, and these should reflect the aspects of the service of most importance to the customer. 
-All the considerations following are nuances of this underlying theme.
+The SLO is based on good SLIs, and these should reflect the aspects of the service of most importance to the customer. All the considerations following are nuances of this underlying theme.
 
-It's important to understand the outcomes of setting an SLO. These outcomes differ depending on multiple factors, including both the maturity of the service and the whole organization overall.
-To understand the different SLO settings, let's explore some use-cases that appear at either end of SLO adoption.
+It's important to understand the outcomes of setting an SLO. These outcomes differ depending on multiple factors, including both the maturity of the service and the whole organization overall. To understand the different SLO settings, let's explore some use-cases that appear at either end of SLO adoption.
 
 ## Case 1 - New Service
 
-For this case, imagine a mature SRE organization. In this organization, there are stakeholders spanning SLO [personas](./ADRs/RH/SIG-SRE/ADR-00002%20Personas%20related%20to%20Managed%20Services.md).
-Each stakeholder understands the outcomes of both meeting or missing an SLO. 
+For this case, imagine a mature SRE organization. In this organization, there are stakeholders spanning SLO [personas](./ADRs/RH/SIG-SRE/ADR-00002%20Personas%20related%20to%20Managed%20Services.md). Each stakeholder understands the outcomes of both meeting or missing an SLO.
 
-So with that in mind, what should be the service level objective? 
+So with that in mind, what should be the service level objective?
 
-A new service presents the opportunity to use an SLO to steer development efforts before reaching production. 
-Ideally, a new service in production is both featureful and reliable. Product managers responsible for the service could use an SLO to define the production readiness. 
-SLOs can assist in removing subjectivity about components of a decision and that helps make clear and quantifiable decisions about the service's readiness. 
+A new service presents the opportunity to use an SLO to steer development efforts before reaching production. Ideally, a new service in production is both featureful and reliable. Product managers responsible for the service could use an SLO to define the production readiness. SLOs can assist in removing subjectivity about components of a decision and that helps make clear and quantifiable decisions about the service's readiness.
 
 To learn more about the responsibilities across different personas in an organization, read our [article](./ADRs/RH/SIG-SRE/ADR-00006%20SLO%20RACI%20Chart.md) on the RACI model.
 
-## Case 2 - Existing Service 
+## Case 2 - Existing Service
 
-For this scenario, imagine there's already an SLI for an existing Authentication service in production and defined an SLO. Suddenly, one day, the on-call SRE gets paged that the SLO exceeded the target level.
-After a quick investigation, the on-call SRE notices that the service's 3rd party auth provider is down. Consequently, the auth service is in degraded mode. 
-Since the SLO target is exceeded because of a third-party service, shall the team stop releasing new features?
+For this scenario, imagine there's already an SLI for an existing Authentication service in production and defined an SLO. Suddenly, one day, the on-call SRE gets paged that the SLO exceeded the target level. After a quick investigation, the on-call SRE notices that the service's 3rd party auth provider is down. Consequently, the auth service is in degraded mode. Since the SLO target is exceeded because of a third-party service, shall the team stop releasing new features?
 
-When creating an SLO, external dependencies should be considered, and mitigation strategies should be employed to handle service disruptions from those external dependencies. 
-Once the organization is convinced of the benefits that SLOs bring across multiple teams, retrofitting this into a mature service has some cultural considerations. 
+When creating an SLO, external dependencies should be considered, and mitigation strategies should be employed to handle service disruptions from those external dependencies. Once the organization is convinced of the benefits that SLOs bring across multiple teams, retrofitting this into a mature service has some cultural considerations.
 
-First, all stakeholders have to agree on the outcomes of missing an SLO [burning the error budget](./ADRs/RH/SIG-SRE/ADR-00007-Error-Budget-Policy.md). 
-This decision may take time for engineering teams to digest the idea of slowing feature work and focusing on reliability issues. 
-The goal here should be the balance of direct impact on current processes vs introducing new processes. 
+First, all stakeholders have to agree on the outcomes of missing an SLO [burning the error budget](./ADRs/RH/SIG-SRE/ADR-00007-Error-Budget-Policy.md). This decision may take time for engineering teams to digest the idea of slowing feature work and focusing on reliability issues. The goal here should be the balance of direct impact on current processes vs introducing new processes.
 
-There are two main paths this could be navigated, and each should consider if there is pre-existing data that provides a baseline of current service levels. 
-* Set a high SLO to start with and work towards it. What is high? 99.9%? This decision depends on if you can approximate the current service levels being delivered. 
+There are two main paths this could be navigated, and each should consider if there is pre-existing data that provides a baseline of current service levels.
+
+* Set a high SLO to start with and work towards it. What is high? 99.9%? This decision depends on if you can approximate the current service levels being delivered.
 * Set a [permissive SLO](./ADRs/RH/SIG-SRE/ADR-00005%20SLO%20Lifecycle.md#permissive-slo-phase=) as a lightweight target goal. The service owners engage in the practice of SLOs, but without any "enforcing" aspect to the SLO lifecycle.
 
-# Tips
+## Tips
+
 * Have good SLIs based on what is important to customers.
 * Reflect on customer experience: Customer satisfaction drives the sustainability of the business, so make sure to focus on critical paths that make customers happy.
 * Define Expectations vs Reality SLOs: Distinct aspirational SLO target levels from those you can acually achieve.
-* Start somewhere: Don't wait until you find the best target levels to create an SLO. 
+* Start somewhere: Don't wait until you find the best target levels to create an SLO.
 * Iterate often: You need continuously re-evaluate reliability targets and update the SLOs based on more realistic target goals.
 * Never forget external dependencies: Monitoring external dependencies and considering them while crafting SLOs is important as they have a direct impact on the reliability targets.
 
-To learn more about the SLO lifecycle check our [article](./ADRs/RH/SIG-SRE/ADR-00005%20SLO%20Lifecycle.md) to give you a glimpse of our approach.  
+To learn more about the SLO lifecycle check our [article](./ADRs/RH/SIG-SRE/ADR-00005%20SLO%20Lifecycle.md) to give you a glimpse of our approach.

--- a/process/incident_management.md
+++ b/process/incident_management.md
@@ -1,6 +1,7 @@
 # Incident Management Process
 
 ## Introduction
+
 The goal of this page is to document the incident management process.
 
 It aims at formalizing the roles of the different actors while working on a **major** incident, as well as describing the high level course of actions and mandatory steps that need to be taken to minimize MTTR (=Mean Time To Recover/Repair, so ensuring quick recovery of our services) and proper customer communication and satisfaction throughout the process.
@@ -10,6 +11,7 @@ There can be multiple levels of severity for an incident depending on the impact
 A major outage can be defined when our platform is running out of error budget or when we start failing our SLOs.
 
 Examples of major incidents:
+
 * Full outage or heavy degradation of one or multiple services impacting one or several customers
 * Duration of the incident is greater than 4 hours
 * Multiple layers and SRE teams are impacted (platform, application, …)
@@ -17,6 +19,7 @@ Examples of major incidents:
 Note that when a team has a path for fast recovery then they shouldn't break it to fit that process if it's not required.
 
 ## Quick reference guide
+
 In case of a customer–impacting incident (persisting or intermittent degradation of customer–exposed functionality):
 
 1. The Incident First Responder is the first SRE being alerted of the issue and starting the investigation
@@ -31,6 +34,7 @@ In case of a customer–impacting incident (persisting or intermittent degradati
 5. The Incident Owner (usually the First Responder unless the Incident Commander picked someone else) is responsible for running and documenting the post mortem and root cause analysis and bring the incident to full closure.
 
 ## Incidents
+
 An incident is an event that can occur at any time and which results in a degradation or outage of one or multiple of our services.
 
 An incident can be raised by a customer or directly by our monitoring and alerting systems, or directly by a member of the SRE team.
@@ -49,7 +53,9 @@ As an SRE organization we should aim at:
 ## Roles and Responsibilities
 
 ### Incident First Responder
+
 Any SRE investigating a cluster issue becomes this, when they notice a **problem with a cluster or a specific application**  which:
+
 * may be a **customer–facing cluster having an issue impacting (degradation or outage)**
 * or cause **imminent major outage.**
 
@@ -57,8 +63,8 @@ A major outage can be defined as one where our platform is running out of error 
 
 SRE teams have the concept of an on-duty shift person who is responsible for answering to alerts and incidents while the rest of the team is focusing on engineering work. These persons will usually be First Responders. Most often a shift Primary or Secondary become First Responders while investigating ongoing cases/alerts.
 
-
 #### Initial Response
+
 Before doing any further troubleshooting, First Responder must, in order:
 
 1. **Create a bridge.**
@@ -69,24 +75,29 @@ Before doing any further troubleshooting, First Responder must, in order:
 Only now can you continue debugging while describing the problem to people joining the bridge.
 
 #### 10 Minutes Later
+
 **If** 10 minutes after your announcement your **region lead or manager haven’t joined** the bridge and you haven't managed to recover the service:
+
 * halt any further technical work
 * **pick an Incident Commander** from among the SREs present.
 
 Only now can you continue debugging.
 
-#### Comments / Reasoning
+#### First Responder Comments / Reasoning
+
 * **The First Responder Protocol is the most important part.**
 * It needs to be:
   * **as short as possible** – since everybody needs to know it by heart,
   * **as simple and unambiguous as possible** – because it needs to guarantee proper bootstrapping of the full Incident Management Process even by someone who’s still in training and accidentally stumbled upon a serious issue.
 
 ### Incident Owner
+
 * The Incident Owner is by default the First Responder
 * The Incident Owner role is not handed over from one shift to the next and stays the same throughout the lifecycle of the incident unless the current owner doesn't feel confident or can't assume the role throughout the incident. In that case the role can be handed over and the handover needs to be fully documented and communicated to the wider team.
 * The incident ticket is assigned to the Incident Owner
 
 #### Responsibilities
+
 The main responsibility of the Incident Owner is to assume the complete ownership of the incident from a technical standpoint:
 
 * Understanding the course of the incident and its technical details from start to finish
@@ -103,11 +114,13 @@ The Incident Owner is also making sure that the Post Mortem Review (PMR) is orga
 The incident owner must make sure that the different action items from the PMR are being worked on and addressed in a timely fashion and so make sure that they are prioritized accordingly in the backlog of the functional teams.
 
 ### Incident Technical Lead
+
 * The incident technical lead is by default the First Responder
-* An Incident Technical Lead **can be changed only by an __explicit decision__ of the Incident Commander.**
+* An Incident Technical Lead **can be changed only by an **explicit decision** of the Incident Commander.**
   * If you’re a First Responder, but don’t want to be the Lead, you must coordinate that change with the Incident Commander.
 
-#### Responsibilities
+#### Technical Lead Responsibilities
+
 The technical lead of an incident is in charge of leading the technical investigation of the incident and make sure that it is recovered as quickly as possible.
 
 If the incident is not resolved at the end of the current shift then the Incident Tech Lead role gets handed over to the next shift, while Incident Owner is not.
@@ -115,15 +128,18 @@ If the incident is not resolved at the end of the current shift then the Inciden
 The Incident Tech Lead is responsible to contribute to the documentation of what happened in the RCA document and help the Incident Owner (if not self) to close any gaps in the overall management of the incident
 
 Summary:
+
 * Is in charge of the investigation and recovery
 * Role is handed over from one shift to the other until full resolution
 * Helps the Incident Owner document the RCA and PMR Action Items.
 
 ### Supporting SRE / Parallel Investigator
+
 A parallel investigator is someone who will be involved hands-on in investigating and helping the fast recovery of the incident.
 A parallel investigator will get involved either by the Incident Commander or by any other members of the IM channel.
 
-#### Responsibilities
+#### Supporting SRE Responsibilities
+
 The investigators have the responsibility to describe the action they are taking in the dedicated IM channel to ensure that there is awareness on the steps being taken for the recovery of everyone involved in the process. This can also be done by someone else assisting in the investigation while the main investigator is busy with the recovery.
 
 ### Incident Commander
@@ -132,46 +148,50 @@ The key element for this role is for the Incident Commander to be solely focused
 
 The Incident Commander can elect someone to be the "scribe" during the incident. The duty of the scribe is to report in the RCA document all the important information (technical details, timeline, ...) while the Incident Commander is focused on helping with the coordination.
 
-#### Responsibilities
+#### Incident Commander Responsibilities
+
 The coordination work under the responsibility of the Incident Commander is as follows:
+
 1. If the incident has been uncovered by SRE and doesn't have an existing "external" ticket then the Incident Commander will create a ticket to track the overall life of the incident.
 2. Right after the Incident Commander will create a dedicated IM channel:
-  * Making sure that we have a dedicated IM channel opened specifically for the ongoing incident
-    1. Channel is public
-    2. Naming convention for the IM channel should start with the ticket number and the clusterid if available.
-        * Example:
-          * [ticket-nb]-[clusterid]
-          * [ticket-nb]-[service]
-    3. The description of the IM channel should record:
-        * Incident Commander
-        * Incident Tech Lead
-        * Bridge link
-        * A small description of the issue
-    4. Making sure the right people are invited in the IM channel (including customer support if need be)
-    5. Making sure that all communications and information flows are recorded in the IM channel (it will help with the Post Mortem Review process and making sure that we have the right timeline)
-  3. Using IM, post a message to the relevant channel with:
+    * Making sure that we have a dedicated IM channel opened specifically for the ongoing incident
+      1. Channel is public
+      2. Naming convention for the IM channel should start with the ticket number and the clusterid if available.
+          * Example:
+            * `[ticket-nb]-[clusterid]`
+            * `[ticket-nb]-[service]`
+      3. The description of the IM channel should record:
+          * Incident Commander
+          * Incident Tech Lead
+          * Bridge link
+          * A small description of the issue
+      4. Making sure the right people are invited in the IM channel (including customer support if need be)
+      5. Making sure that all communications and information flows are recorded in the IM channel (it will help with the Post Mortem Review process and making sure that we have the right timeline)
+3. Using IM, post a message to the relevant channel with:
     * **link to bridge**
     * **link to the dedicated IM channel (see point 2.)**
     * **short description of issue (which cluster, what’s failing)**
-  4. Post an incident notification to the customer(s)
-  5. Create right away the RCA document and ensure that it contains the relevant information which would record the high level timeline of events and help during handovers if the incident becomes a long running one.
-  6. Designate the Incident Owner / confirm the First Responder will be that, announce it officially in the different channels, document it in the RCA document and assign the Incident ticket to the Incident Owner.
-  7. Designate an Incident Technical Lead (on the first shift it will be the Incident Owner but then if the incident spans across multiple shifts this role will be handed over to the next)
-  8. Publicly announce who is Incident Commander (IC) in the dedicated IM channel.
-  9. Trigger oncall for the right groups that are needed for helping out with the recovery
-  10. Making sure that regular updates are being given in the IM channel in addition to curated information for the customer.
-  11. Provide executive summary of the ongoing state of the incident
+4. Post an incident notification to the customer(s)
+5. Create right away the RCA document and ensure that it contains the relevant information which would record the high level timeline of events and help during handovers if the incident becomes a long running one.
+6. Designate the Incident Owner / confirm the First Responder will be that, announce it officially in the different channels, document it in the RCA document and assign the Incident ticket to the Incident Owner.
+7. Designate an Incident Technical Lead (on the first shift it will be the Incident Owner but then if the incident spans across multiple shifts this role will be handed over to the next)
+8. Publicly announce who is Incident Commander (IC) in the dedicated IM channel.
+9. Trigger oncall for the right groups that are needed for helping out with the recovery
+10. Making sure that regular updates are being given in the IM channel in addition to curated information for the customer.
+11. Provide executive summary of the ongoing state of the incident
 
-#### Comments / Reasoning
+#### Incident Commander Comments / Reasoning
+
 If half of each region is trained to be good at doing this, that's enough to always get a great incident response no matter who the First Responder is.
 
-
 ### Customer support Lead
+
 The customer support lead is the person from our first level support organization who is going to handle the customer notification and communication throughout the duration of the incident, based on the information provided by the Incident Commander.
 
 When an incident is initially triggered or managed internally to SRE, meaning that it was not initiated by a customer request through Customer support and when this incident has an impact to the customer then the Incident Commander needs to ensure that the right representation from Customer Support is available in the bridge.
 
 ## After incident recovery
+
 Once our services are recovered and we are back in business then the following steps must happen:
 
 * Incident ticket is updated accordingly by the Incident Owner
@@ -186,6 +206,7 @@ Once our services are recovered and we are back in business then the following s
 Templates for RCA and PMR documents can be found here.
 
 ### Return to baseline
+
 The recovery of an incident consists of making sure that there is no more impact to the customer using our services.
 But in some cases it means that the system is not yet fully back to its original desired state (loss of resilience, manual non persisted config change, ...).
 So the return to baseline is the process that ensures that we are back in a nominal state with regards to the resilience of the service or its model driven configuration/state.
@@ -193,14 +214,17 @@ NOTE: confirm monitoring has returned to baseline by ensuring any alert silences
 This is the very next step after recovery of the service.
 
 ### Root Cause Analysis
+
 Once the system is recovered and back to its nominal state then we shall ensure that we investigate and understand the root cause of the incident. This will allow us to make sure that we can find the best countermeasures or fixes to avoid re-occurrence. It has been found highly effective for the major roles within the incident to take a break after **Return to baseline** to refresh themselves and then return for a 30 minute scavenger hunt to produce the initial timeline. The point is to immediately explore, scope and shape the timeline using all available data as well as proposing drafts for follow up actions while the incident is still fresh in the minds of engineers.
 
 ## Post Mortem Review
+
 A post mortem review is mandatory after each major incident and should happen in the next 5 business days after recovery of the incident, while the events are still fresh in everybody's mind.
 
 **Very important: the post mortem review is a blameless exercise. Human error is inevitable and our goal is always to find the right process and tooling. Focus on the objective facts of the event and offer constructive input to where we can improve.**
 
 The post mortem meeting should involve all internal parties who were involved in the recovery itself and should be scheduled publicly to allow anyone interested to join and listen in or contribute:
+
 * [mandatory] The incident commander
 * [mandatory] The incident technical lead
 * [optional] Every SRE team members involved (as much as possible given the timezone constraints)
@@ -208,6 +232,7 @@ The post mortem meeting should involve all internal parties who were involved in
 * [optional] The Customer Support lead
 
 The incident technical lead is the owner of the post mortem review meeting and is making sure that it contains the following:
+
 * Executive summary with customer impact, severity, …
 * Root Cause Analysis
 * Timeline of events
@@ -227,19 +252,21 @@ All action items and countermeasures should aim at (as much as possible):
 * Decrease MTTR in case of recurrence (documentation for instance, …)
 * **Each action item must be tracked by a corresponding ticket in the SRE's backlog so that its implementation can be prioritized and tracked by the SRE leads**
 
-
 Questionnaire to be answered during the PMR:
+
 * How can we protect ourselves better from such an incident?
 * How can we ensure that the issue does not reoccur?
 * How can we recover quicker from such an incident?
 * How can we identify the issue quicker?
 
 ## Detailed process steps
+
 This section aims at presenting the steps that need to be taken in case of a new incident.
 
 ![flow chart](resources/im_flowchart.png)
 
 ## Handoff
+
 Some major incidents will span shift handoff between regions. When this happens:
 
 1. Outgoing Incident Commander identifies an incoming Incident Commander
@@ -254,10 +281,12 @@ Some major incidents will span shift handoff between regions. When this happens:
 Note: Outgoing team members should disengage no later than 30 minutes after their region handoff time (handoff+30).
 
 Some example permitted activities after handoff+30:
+
 * answer questions that were missed at handoff
 * final updates to stakeholders to communicate handoff status
 
 Some example prohibited activities after handoff+30:
+
 * any hands-on-keyboard SRE work
 
 The purpose of this guideline is to ensure only rested, clear-headed SREs are working on our Production systems, and to discourage burn-out.

--- a/process/incident_management.md
+++ b/process/incident_management.md
@@ -176,7 +176,7 @@ The coordination work under the responsibility of the Incident Commander is as f
 6. Designate the Incident Owner / confirm the First Responder will be that, announce it officially in the different channels, document it in the RCA document and assign the Incident ticket to the Incident Owner.
 7. Designate an Incident Technical Lead (on the first shift it will be the Incident Owner but then if the incident spans across multiple shifts this role will be handed over to the next)
 8. Publicly announce who is Incident Commander (IC) in the dedicated IM channel.
-9. Trigger oncall for the right groups that are needed for helping out with the recovery
+9. Trigger on-call for the right groups that are needed for helping out with the recovery
 10. Making sure that regular updates are being given in the IM channel in addition to curated information for the customer.
 11. Provide executive summary of the ongoing state of the incident
 

--- a/prometheus_alerting_consistency.md
+++ b/prometheus_alerting_consistency.md
@@ -60,7 +60,7 @@ Example critical alert:
     runbook_url: 'https://example.com/backend_service_stuck.asciidoc'
 ```
 
-This alert fires if a backend service has *not* been ready for a pre-configured time. To avoid false alarms the chosen timeout MUST be long enough that it is unlikely to be reached during any routine restart or deployment. 
+This alert fires if a backend service has *not* been ready for a pre-configured time. To avoid false alarms the chosen timeout MUST be long enough that it is unlikely to be reached during any routine restart or deployment.
 This is a clear example of a critical issue that represents a threat to the operability of the service, and likely warrants paging someone.
 The alert has a clear summary and description annotations, and it links to a runbook with information on investigating and resolving the issue.
 If there is an SLO related to the alert, mention it in the description so the responder knows why the alert is important.

--- a/slo_bootstrap_guide.md
+++ b/slo_bootstrap_guide.md
@@ -6,7 +6,7 @@ Red Hat's SIG-SRE group has created a set of documents which share how some team
 
 ### Step 1: Familiarise Definitions
 
-**Service Level Objective (SLO)** - A Service Level Objective is a specific, measurable target to express the level of service provided to a service's custoemrs, be they internal or external. These **objectives** can be focused on a particular aspect of the service, such as a specific API endpoint.
+**Service Level Objective (SLO)** - A Service Level Objective is a specific, measurable target to express the level of service provided to a service's customers, be they internal or external. These **objectives** can be focused on a particular aspect of the service, such as a specific API endpoint.
 
 **Service Level Indicator (SLI)** - A Service Level Indicator (SLI) is a specific metric that is used to measure against the objective. These **indicators** may be exposed through the service (“white box”) itself or measured in a way that is external to the service (“black box”).
 

--- a/sre_maturity.md
+++ b/sre_maturity.md
@@ -88,13 +88,13 @@ Your alerts have matured and rarely give false positives as a result of having t
   - Avoid SRE having sub-systems that automagically work around the inefficiencies of upstream - needs a good argument why it can’t be fixed upstream - pushing left
 - Combination of internal (whitebox) and external (blackbox) monitoring - tied to SLOs
 - Dashboards, logging (easily accessible)
-- Improving the architecture for lower cost to serve. Pereq here - calculating & knowing the cost to serve
+- Improving the architecture for lower cost to serve. Prereq here - calculating & knowing the cost to serve
 
 ### Observability - Phase 3: The 'Run' Phase
 
 *This section needs elaboration. Please help by adding content. Ref: [SIGSRE-78](https://issues.redhat.com/browse/SIGSRE-78)*
 
-- Observability correlation beteween logs, metrics, alerts, events etc..
+- Observability correlation between logs, metrics, alerts, events etc..
 - build on this foundation looking at AI Ops and improving the debug experience (focused on decreasing MTTR further)
   - Needs everything underneath it first (all the signals)
 - SLOs - Well established SLO Review process

--- a/sre_maturity.md
+++ b/sre_maturity.md
@@ -1,33 +1,33 @@
 # SRE Maturity
 
-  - [People and Culture](#people-and-culture)
-    - [People and Culture - Phase 1: The ‘Crawl’ Phase](#people-and-culture---phase-1-the-crawl-phase)
-    - [People and Culture - Phase 2: The 'Walk' Phase](#people-and-culture---phase-2-the-walk-phase)
-    - [People and Culture - Phase 3: The 'Run' Phase](#people-and-culture---phase-3-the-run-phase)
-  - [Observability](#observability)
-    - [Observability - Phase 1: The ‘Crawl’ Phase](#observability---phase-1-the-crawl-phase)
-    - [Observability - Phase 2: The 'Walk' Phase](#observability---phase-2-the-walk-phase)
-    - [Observability - Phase 3: The 'Run' Phase](#observability---phase-3-the-run-phase)
-  - [On Call, Escalations and Incidents](#on-call-escalations-and-incidents)
-    - [On Call, Escalations and Incidents - Phase 1: The ‘Crawl’ Phase](#on-call-escalations-and-incidents---phase-1-the-crawl-phase)
-    - [On Call, Escalations and Incidents - Phase 2: The 'Walk' Phase](#on-call-escalations-and-incidents---phase-2-the-walk-phase)
-    - [On Call, Escalations and Incidents - Phase 3: The 'Run' Phase](#on-call-escalations-and-incidents---phase-3-the-run-phase)
-  - [Failures](#failures)
-    - [Failures - Phase 1: The ‘Crawl’ Phase](#failures---phase-1-the-crawl-phase)
-    - [Failures - Phase 2: The 'Walk' Phase](#failures---phase-2-the-walk-phase)
-    - [Failures - Phase 3: The 'Run' Phase](#failures---phase-3-the-run-phase)
-  - [Security](#security)
-    - [Security - Phase 1: The ‘Crawl’ Phase](#security---phase-1-the-crawl-phase)
-    - [Security - Phase 2: The 'Walk' Phase](#security---phase-2-the-walk-phase)
-    - [Security - Phase 3: The 'Run' Phase](#security---phase-3-the-run-phase)
-  - [Room to improve](#room-to-improve)
-    - [Room to improve - Phase 1: The ‘Crawl’ Phase](#room-to-improve---phase-1-the-crawl-phase)
-    - [Room to improve - Phase 2: The 'Walk' Phase](#room-to-improve---phase-2-the-walk-phase)
-    - [Room to improve - Phase 3: The 'Run' Phase](#room-to-improve---phase-3-the-run-phase)
-  - [Releasing](#releasing)
-    - [Releasing - Phase 1: The ‘Crawl’ Phase](#releasing---phase-1-the-crawl-phase)
-    - [Releasing - Phase 2: The 'Walk' Phase](#releasing---phase-2-the-walk-phase)
-    - [Releasing - Phase 3: The 'Run' Phase](#releasing---phase-3-the-run-phase)
+- [People and Culture](#people-and-culture)
+  - [People and Culture - Phase 1: The ‘Crawl’ Phase](#people-and-culture---phase-1-the-crawl-phase)
+  - [People and Culture - Phase 2: The 'Walk' Phase](#people-and-culture---phase-2-the-walk-phase)
+  - [People and Culture - Phase 3: The 'Run' Phase](#people-and-culture---phase-3-the-run-phase)
+- [Observability](#observability)
+  - [Observability - Phase 1: The ‘Crawl’ Phase](#observability---phase-1-the-crawl-phase)
+  - [Observability - Phase 2: The 'Walk' Phase](#observability---phase-2-the-walk-phase)
+  - [Observability - Phase 3: The 'Run' Phase](#observability---phase-3-the-run-phase)
+- [On Call, Escalations and Incidents](#on-call-escalations-and-incidents)
+  - [On Call, Escalations and Incidents - Phase 1: The ‘Crawl’ Phase](#on-call-escalations-and-incidents---phase-1-the-crawl-phase)
+  - [On Call, Escalations and Incidents - Phase 2: The 'Walk' Phase](#on-call-escalations-and-incidents---phase-2-the-walk-phase)
+  - [On Call, Escalations and Incidents - Phase 3: The 'Run' Phase](#on-call-escalations-and-incidents---phase-3-the-run-phase)
+- [Failures](#failures)
+  - [Failures - Phase 1: The ‘Crawl’ Phase](#failures---phase-1-the-crawl-phase)
+  - [Failures - Phase 2: The 'Walk' Phase](#failures---phase-2-the-walk-phase)
+  - [Failures - Phase 3: The 'Run' Phase](#failures---phase-3-the-run-phase)
+- [Security](#security)
+  - [Security - Phase 1: The ‘Crawl’ Phase](#security---phase-1-the-crawl-phase)
+  - [Security - Phase 2: The 'Walk' Phase](#security---phase-2-the-walk-phase)
+  - [Security - Phase 3: The 'Run' Phase](#security---phase-3-the-run-phase)
+- [Room to improve](#room-to-improve)
+  - [Room to improve - Phase 1: The ‘Crawl’ Phase](#room-to-improve---phase-1-the-crawl-phase)
+  - [Room to improve - Phase 2: The 'Walk' Phase](#room-to-improve---phase-2-the-walk-phase)
+  - [Room to improve - Phase 3: The 'Run' Phase](#room-to-improve---phase-3-the-run-phase)
+- [Releasing](#releasing)
+  - [Releasing - Phase 1: The ‘Crawl’ Phase](#releasing---phase-1-the-crawl-phase)
+  - [Releasing - Phase 2: The 'Walk' Phase](#releasing---phase-2-the-walk-phase)
+  - [Releasing - Phase 3: The 'Run' Phase](#releasing---phase-3-the-run-phase)
 
 ## People and Culture
 
@@ -51,13 +51,13 @@ They should help you advocate for service features that make the service more re
 
 *This is a stub. Please help by adding content. Ref: [SIGSRE-75](https://issues.redhat.com/browse/SIGSRE-75)*
 
-* Starting to get Exec support (improvement on 'buy-in')
+- Starting to get Exec support (improvement on 'buy-in')
 
 ### People and Culture - Phase 3: The 'Run' Phase
 
 *This is a stub. Please help by adding content. Ref: [SIGSRE-76](https://issues.redhat.com/browse/SIGSRE-76)*
 
-* Exec engagement
+- Exec engagement
 
 ## Observability
 
@@ -81,23 +81,23 @@ You have established patterns and guidelines for observability signals such as m
 You are using these patterns to speed up debugging of issues and to be to able to correlate various signals more easily, thereby reducing your Mean Time To Recovery (MTTR).
 Your alerts have matured and rarely give false positives as a result of having these patterns and refining queries.
 
-* SLOs - SLOs have been iterated on, and you have more than 1 meaningful SLO.
-* You understand and track error budgets
-* Your alerts are actionable
-* Your systems are self healing
-  * Avoid SRE having sub-systems that automagically work around the inefficiencies of upstream - needs a good argument why it can’t be fixed upstream - pushing left
-* Combination of internal (whitebox) and external (blackbox) monitoring - tied to SLOs
-* Dashboards, logging (easily accessible)
-* Improving the architecture for lower cost to serve. Pereq here - calculating & knowing the cost to serve
+- SLOs - SLOs have been iterated on, and you have more than 1 meaningful SLO.
+- You understand and track error budgets
+- Your alerts are actionable
+- Your systems are self healing
+  - Avoid SRE having sub-systems that automagically work around the inefficiencies of upstream - needs a good argument why it can’t be fixed upstream - pushing left
+- Combination of internal (whitebox) and external (blackbox) monitoring - tied to SLOs
+- Dashboards, logging (easily accessible)
+- Improving the architecture for lower cost to serve. Pereq here - calculating & knowing the cost to serve
 
 ### Observability - Phase 3: The 'Run' Phase
 
 *This section needs elaboration. Please help by adding content. Ref: [SIGSRE-78](https://issues.redhat.com/browse/SIGSRE-78)*
 
-* Observability correlation beteween logs, metrics, alerts, events etc..
-* build on this foundation looking at AI Ops and improving the debug experience (focused on decreasing MTTR further)
-  * Needs everything underneath it first (all the signals)
-* SLOs - Well established SLO Review process
+- Observability correlation beteween logs, metrics, alerts, events etc..
+- build on this foundation looking at AI Ops and improving the debug experience (focused on decreasing MTTR further)
+  - Needs everything underneath it first (all the signals)
+- SLOs - Well established SLO Review process
 
 ## On Call, Escalations and Incidents
 
@@ -141,7 +141,7 @@ You understand how the service reacts to failures and feed the output into plann
 
 Validate well established and iterated SLOs under turbulent conditions in addition to making sure right alerts are in place given that observability maturity is part of this phase
 
-* Disaster Recovery & Incident Rehearsals
+- Disaster Recovery & Incident Rehearsals
 
 ### Failures - Phase 3: The 'Run' Phase
 
@@ -171,7 +171,7 @@ Companies may also have your own internal compliance processes or security stand
 Those compliance certifications/attestations are the tangible items you can give to your customers to provide assurances of your security posture.
 
 Background checks are implemented for individuals with privileged access to the environment.
-The number of background checks needed grows linearly with the individuals with privileged access 
+The number of background checks needed grows linearly with the individuals with privileged access
 
 Security activities that were previously ad-hoc are now running regularly for each release, scanning your source & your production environment.
 Doing 'security impact assessments' at the design phase of service features and architecture decisions pushes you security awareness earlier in the process.
@@ -182,7 +182,7 @@ All code dependencies are being scanned for vulnerabilities and you are responsi
 
 *This is a stub. Please help by adding content. Ref: [SIGSRE-85](https://issues.redhat.com/browse/SIGSRE-85)*
 
-* Automated Policy enforcement
+- Automated Policy enforcement
 
 ## Room to improve
 
@@ -199,8 +199,8 @@ That can come later, however you are familiar with the concept of Toil.
 
 *This is a stub. Please help by adding content. Ref:[SIGSRE-86](https://issues.redhat.com/browse/SIGSRE-86)*
 
-* Start measuring Toil more formally & management track it
-  * Develop relationship with the upstream (eng and sre, or sre & upstream product) for managing toil
+- Start measuring Toil more formally & management track it
+  - Develop relationship with the upstream (eng and sre, or sre & upstream product) for managing toil
 
 ### Room to improve - Phase 3: The 'Run' Phase
 
@@ -212,12 +212,12 @@ That can come later, however you are familiar with the concept of Toil.
 
 ### Releasing - Phase 1: The ‘Crawl’ Phase
 
-* One-off Release Scripts
+- One-off Release Scripts
 
 ### Releasing - Phase 2: The 'Walk' Phase
 
-* Robust CI/CD Practices
+- Robust CI/CD Practices
 
 ### Releasing - Phase 3: The 'Run' Phase
 
-* Canary Releases
+- Canary Releases


### PR DESCRIPTION
This change will address the spelling errors that slipped past on iniital reviews and hopefully has caught them all. There is a mix of British and English spelling which I did not correct one way or another.

The larger changes have to do with markdownlint. As mentioned in the [README.md](/operate-first/sre/README.md)'s contributing section, we wish for markdownlint to be used. I disabled [rule 37](https://github.com/DavidAnson/markdownlint/blob/v0.26.2/doc/Rules.md#md037) because we have an explicit use case of it that I am not prepared to change at this time (this change is not meant to change content or presentation).