### PR TITLE
proposing a community of practice roadmap

### DIFF
--- a/sig-roadmap.md
+++ b/sig-roadmap.md
@@ -1,0 +1,35 @@
+# SIG SRE roadmap
+
+This is a roadmap for a site reliability engineering (SRE) community of practice.
+It encompasses activities that include:
+- Creating and sustaining discussions about areas of practice
+- Initiating working groups (WGs) as a sign of forking a discussion into action oriented to creating one or more artifacts
+- Artifact creation such as practice guides, tool sets, service catalogs, etc.
+
+Discussions and decisions about this roadmap occur on the main group [sig-sre@operate-first.cloud](https://lists.operate-first.cloud/archives/list/sig-sre@operate-first.cloud/).
+
+## Roadmap
+
+### Done
+* Marketing and communications:
+  * [The Reliability Nightmares Colouring Book](https://github.com/operate-first/sre/raw/main/sre-coloring-book/red-hat-sre-coloring-book.pdf)
+* Practice guides:
+  * [The SLO Bootstrap Guide](./slo_bootstrap_guide.md)
+  * [Incident Management Process Guide](./process/incident_management.md)
+  * [Picking good Service Level Indicators (SLIs)](./picking_good_slis.md)
+  * [Picking good Service Level Objectives (SLOs)](./picking_good_slos.md)
+  * [Prometheus Alerting Consistency](./prometheus_alerting_consistency.md)
+
+### Doing
+* Growing set of sample SIG-SRE [Architecture Decision Records](./ADRs/RH/SIG-SRE)
+
+
+### Planning
+* A work in progress - the [SRE Maturity Model](./sre_maturity.md)
+* Governance for this SIG
+
+### Envisioning
+* Growing membership of the SIG from across the cloud native and Open Source ecosystems of customers, vendors, and Open Source communities.
+* Forming an SRE TAG of the CNCF.
+* Collaborating with [The Maintainers](https://themaintainers.org) cross-industry community of practice.
+*


### PR DESCRIPTION
- builds from the idea of /sre becoming the home to an external community of practice
- as a placeholder and initial proposal it is called "SIG SRE"
- it contains all the work done to date by the SRE team from Red Hat
- it includes some visions I've heard from others or envisioned myself