### PR TITLE
Clarify when RCA should be ready to be shared publicly

### DIFF
--- a/process/incident_management.md
+++ b/process/incident_management.md
@@ -203,7 +203,8 @@ Once our services are recovered and we are back in business then the following s
 * The Post Mortem Review (PMR) is scheduled and run by the Incident Owner in the next 5 business days
 * That the above steps are being performed in a timely manner is verified by the Incident Commander.
 
-From the incident announcement RCA should be ready to be shared publicly in the next 7 business days. This includes resolving all the outstanding comments and approval if required.
+The RCA should be ready to be shared publicly within 7 business days of the incident announcement.
+This includes ensuring all outstanding comments are resolved and any required approvals granted.
 
 ### Return to baseline
 

--- a/process/incident_management.md
+++ b/process/incident_management.md
@@ -203,8 +203,6 @@ Once our services are recovered and we are back in business then the following s
 * The Post Mortem Review (PMR) is scheduled and run by the Incident Owner in the next 5 business days
 * That the above steps are being performed in a timely manner is verified by the Incident Commander.
 
-Templates for RCA and PMR documents can be found here.
-
 From the incident announcement RCA should be ready to be shared publicly in the next 7 business days. This includes resolving all the outstanding comments and approval if required.
 
 ### Return to baseline

--- a/process/incident_management.md
+++ b/process/incident_management.md
@@ -205,6 +205,8 @@ Once our services are recovered and we are back in business then the following s
 
 Templates for RCA and PMR documents can be found here.
 
+From the incident announcement RCA should be ready to be shared publicly in the next 7 business days. This includes resolving all the outstanding comments and approval if required.
+
 ### Return to baseline
 
 The recovery of an incident consists of making sure that there is no more impact to the customer using our services.


### PR DESCRIPTION
Follow up on Incident Management Process improvement for RCA that has been delayed in public sharing due to unclear responsibilities of the Incident Owner. https://issues.redhat.com/browse/OHSS-15947